### PR TITLE
Testing repeat channels

### DIFF
--- a/drivers/iio/dummy/iio_simple_dummy.c
+++ b/drivers/iio/dummy/iio_simple_dummy.c
@@ -221,6 +221,21 @@ static const struct iio_chan_spec iio_dummy_channels[] = {
 			.shift = 0, /* zero shift */
 		},
 	},
+	/* Rotation channel with 4 repeated elements */
+	{
+		.type = IIO_ROT,
+		.modified = 1,
+		.channel2 = IIO_MOD_QUATERNION,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.scan_index = DUMMY_INDEX_ROT,
+		.scan_type = {
+			.sign = 's',
+			.realbits = sizeof(uint16_t) * 8,
+			.storagebits = sizeof(uint16_t) * 8,
+			.endianness = IIO_LE,
+			.repeat = 4,
+		},
+	},
 	/* Convenience macro for timestamps */
 	IIO_CHAN_SOFT_TIMESTAMP(DUMMY_INDEX_TIMESTAMP),
 	/* DAC channel out_voltage0_raw */
@@ -313,6 +328,16 @@ static int iio_dummy_read_raw_multi(struct iio_dev *indio_dev,
 			vals[0] = st->accel_val;
 			*val_len = 1;
 			ret = IIO_VAL_INT;
+			break;
+		case IIO_ROT:
+			if (max_len >= 4) {
+				vals[0] = st->rotation_val[0];
+				vals[1] = st->rotation_val[1];
+				vals[2] = st->rotation_val[2];
+				vals[3] = st->rotation_val[3];
+				*val_len = 4;
+				ret = IIO_VAL_INT_MULTIPLE;
+			}
 			break;
 		default:
 			break;
@@ -564,6 +589,10 @@ static int iio_dummy_init_device(struct iio_dev *indio_dev)
 	st->steps = 47;
 	st->activity_running = 98;
 	st->activity_walking = 4;
+	st->rotation_val[0] = 52;
+	st->rotation_val[1] = 126;
+	st->rotation_val[2] = 51;
+	st->rotation_val[3] = 75;
 
 	return 0;
 }

--- a/drivers/iio/dummy/iio_simple_dummy.c
+++ b/drivers/iio/dummy/iio_simple_dummy.c
@@ -221,11 +221,8 @@ static const struct iio_chan_spec iio_dummy_channels[] = {
 			.shift = 0, /* zero shift */
 		},
 	},
-	/*
-	 * Convenience macro for timestamps. 4 is the index in
-	 * the buffer.
-	 */
-	IIO_CHAN_SOFT_TIMESTAMP(4),
+	/* Convenience macro for timestamps */
+	IIO_CHAN_SOFT_TIMESTAMP(DUMMY_INDEX_TIMESTAMP),
 	/* DAC channel out_voltage0_raw */
 	{
 		.type = IIO_VOLTAGE,

--- a/drivers/iio/dummy/iio_simple_dummy.h
+++ b/drivers/iio/dummy/iio_simple_dummy.h
@@ -102,6 +102,7 @@ iio_simple_dummy_events_unregister(struct iio_dev *indio_dev)
  * @DUMMY_INDEX_DIFFVOLTAGE_1M2:   first differential channel
  * @DUMMY_INDEX_DIFFVOLTAGE_3M4:   second differential channel
  * @DUMMY_INDEX_ACCELX:            acceleration channel
+ * @DUMMY_INDEX_TIMESTAMP:         timestamp (must be last)
  *
  * Enum provides convenient numbering for the scan index.
  */
@@ -110,6 +111,7 @@ enum iio_simple_dummy_scan_elements {
 	DUMMY_INDEX_DIFFVOLTAGE_1M2,
 	DUMMY_INDEX_DIFFVOLTAGE_3M4,
 	DUMMY_INDEX_ACCELX,
+	DUMMY_INDEX_TIMESTAMP,
 };
 
 #ifdef CONFIG_IIO_SIMPLE_DUMMY_BUFFER

--- a/drivers/iio/dummy/iio_simple_dummy.h
+++ b/drivers/iio/dummy/iio_simple_dummy.h
@@ -42,6 +42,7 @@ struct iio_dummy_state {
 	int steps_enabled;
 	int steps;
 	int height;
+	int rotation_val[4];
 #ifdef CONFIG_IIO_SIMPLE_DUMMY_EVENTS
 	int event_irq;
 	int event_val;
@@ -102,6 +103,7 @@ iio_simple_dummy_events_unregister(struct iio_dev *indio_dev)
  * @DUMMY_INDEX_DIFFVOLTAGE_1M2:   first differential channel
  * @DUMMY_INDEX_DIFFVOLTAGE_3M4:   second differential channel
  * @DUMMY_INDEX_ACCELX:            acceleration channel
+ * @DUMMY_INDEX_ROT:               rotation x, y, z, w channels
  * @DUMMY_INDEX_TIMESTAMP:         timestamp (must be last)
  *
  * Enum provides convenient numbering for the scan index.
@@ -111,6 +113,7 @@ enum iio_simple_dummy_scan_elements {
 	DUMMY_INDEX_DIFFVOLTAGE_1M2,
 	DUMMY_INDEX_DIFFVOLTAGE_3M4,
 	DUMMY_INDEX_ACCELX,
+	DUMMY_INDEX_ROT,
 	DUMMY_INDEX_TIMESTAMP,
 };
 

--- a/drivers/iio/dummy/iio_simple_dummy_buffer.c
+++ b/drivers/iio/dummy/iio_simple_dummy_buffer.c
@@ -31,6 +31,7 @@ static const s16 fakedata[] = {
 	[DUMMY_INDEX_DIFFVOLTAGE_1M2] = -33,
 	[DUMMY_INDEX_DIFFVOLTAGE_3M4] = -2,
 	[DUMMY_INDEX_ACCELX] = 344,
+	[DUMMY_INDEX_ROT] = 30,
 };
 
 /**
@@ -80,8 +81,16 @@ static irqreturn_t iio_simple_dummy_trigger_h(int irq, void *p)
 			j = find_next_bit(indio_dev->active_scan_mask,
 					  indio_dev->masklength, j);
 			/* random access read from the 'device' */
-			data[i] = fakedata[j];
-			len += 2;
+			if (j == DUMMY_INDEX_ROT) {
+				data[i++] = fakedata[j];
+				data[i++] = fakedata[j] + 1;
+				data[i++] = fakedata[j] + 2;
+				data[i++] = fakedata[j] + 3;
+				len += 8;
+			} else {
+				data[i] = fakedata[j];
+				len += 2;
+			}
 		}
 	}
 

--- a/tools/iio/iio_utils.h
+++ b/tools/iio/iio_utils.h
@@ -45,6 +45,7 @@ struct iio_channel_info {
 	unsigned index;
 	unsigned bytes;
 	unsigned bits_used;
+	unsigned repeat;
 	unsigned shift;
 	uint64_t mask;
 	unsigned be;
@@ -61,7 +62,7 @@ static inline int iioutils_check_suffix(const char *str, const char *suffix)
 
 int iioutils_break_up_name(const char *full_name, char **generic_name);
 int iioutils_get_type(unsigned *is_signed, unsigned *bytes, unsigned *bits_used,
-		      unsigned *shift, uint64_t *mask, unsigned *be,
+		      unsigned *repeat, unsigned *shift, uint64_t *mask, unsigned *be,
 		      const char *device_dir, const char *name,
 		      const char *generic_name);
 int iioutils_get_param_float(float *output, const char *param_name,


### PR DESCRIPTION
Add the rotation channel type to sample IIO dummy driver as an example of repeated channels. Also modify tools `iio_info` and `iio_generic_buffer` to test changes.

To test:

```
# setup iio device and trigger
sudo modprobe industrialio kfifo_buf industrialio-sw-trigger
sudo modprobe iio_dummy iio-trig-hrtimer
sudo mkdir /configfs
sudo mount -t configfs none /config
sudo mkdir /config/iio/triggers/hrtimer/instance1

# setup buffer
echo 1 > /sys/bus/iio/devices/iio\:device0/scan_elements/in_rot_quaternion_en
echo 1 > /sys/bus/iio/devices/iio\:device0/scan_elements/in_timestamp_en

# read from buffer
sudo ./generic_buffer -n iio_dummy_part_no -t instance1 -c 2
iio device number being used is 0
iio trigger number being used is 0
/sys/bus/iio/devices/iio:device0 instance1
30.000000 31.000000 32.000000 33.000000 1473803128573475241 
30.000000 31.000000 32.000000 33.000000 1473803128583472908 
```
